### PR TITLE
add =~ and $matchdata

### DIFF
--- a/mrblib/regexp.rb
+++ b/mrblib/regexp.rb
@@ -38,12 +38,15 @@ class PureRegexp
     @option & IGNORECASE == IGNORECASE
   end
 
+  $matchdata = []
+
   def match(str, pos = 0)
     input = Input.new(str, @option).substr(pos)
     m = @root.match(input)
     if block_given?
       yield(m)
     end
+    $matchdata = m || []
     m
   end
 

--- a/mrblib/string.rb
+++ b/mrblib/string.rb
@@ -31,6 +31,10 @@ class String
     end
   end
 
+  def =~(regex)
+    regex =~ self
+  end
+
   def gsub(*args, &block)
     if args[0].is_a? Regexp
       raise ArgumentError.new("wrong number of arguments") unless args.size == 2


### PR DESCRIPTION
mruby regex has no function to use operator `=~`

and $1, $2 also not available 
use global $matchdata as replacement of $1, $2